### PR TITLE
Done

### DIFF
--- a/spec/cents-to-decimals.spec.js
+++ b/spec/cents-to-decimals.spec.js
@@ -21,56 +21,56 @@ describe('centsToDecimals function', () => {
     // console.log(centsToDecimals('12345') === undefined);
 
     // ... complete the test assertion below
-    expect(Function_To_Test(parameter)).toEqual(Expected_Result);
+    expect(centsToDecimals('123')).toEqual(undefined);
   });
 
   it('Returns undefined when NaN value is passed as a parameter.', () => {
     // console.log(centsToDecimals(NaN) === undefined);
 
     // ... complete the test assertion below
-    expect(Function_To_Test(parameter)).toEqual(Expected_Result);
+    expect(centsToDecimals(NaN)).toEqual(undefined);
   });
 
   it('Returns undefined when undefined value is passed as a parameter', () => {
     // console.log(centsToDecimals(undefined) === undefined);
 
     // ... complete the test assertion below
-    expect(Function_To_Test(parameter)).toEqual(Expected_Result);
+    expect(centsToDecimals(undefined)).toEqual(undefined);
   });
 
   it('Returns undefined when parameter is not passed.', () => {
     // console.log(centsToDecimals() === undefined);
 
     // ... complete the test assertion below
-    expect(Function_To_Test(parameter)).toEqual(Expected_Result);
+    expect(centsToDecimals()).toEqual(undefined);
   });
 
   it('Should convert a number of cents to a string representation in a floating number format.', () => {
     // console.log(centsToDecimals(1000).slice(0, 5) === '10.00');
 
     // ... complete the test assertion below
-    expect(Function_To_Test(parameter)).toEqual(Expected_Result);
+    expect(centsToDecimals(1000)).toEqual('10.00$');
 
     // console.log(centsToDecimals(50273).slice(0, 6) === '502.73');
 
     // ... complete the test assertion below
-    expect(Function_To_Test(parameter)).toEqual(Expected_Result);
+    expect(centsToDecimals(50273)).toEqual('502.73$');
 
     // console.log(centsToDecimals(0).slice(0, 4) === '0.00');
 
     // ... complete the test assertion below
-    expect(Function_To_Test(parameter)).toEqual(Expected_Result);
+    expect(centsToDecimals(0)).toEqual('0.00$');
   });
 
   it('Should return a string representation of a number with `$` sign appended at the end.', () => {
     // console.log(centsToDecimals(1000) === '10.00$');
 
     // ... complete the test assertion below
-    expect(Function_To_Test(parameter)).toEqual(Expected_Result);
+    expect(centsToDecimals(1000)).toEqual('10.00$');
 
     // console.log(centsToDecimals(0) === '0.00$');
 
     // ... complete the test assertion below
-    expect(Function_To_Test(parameter)).toEqual(Expected_Result);
+    expect(centsToDecimals(0)).toEqual('0.00$');
   });
 });


### PR DESCRIPTION
The Test _**'Should convert a number of cents to a string representation in a floating number format.'**_ only works when you put a $ on the end of the string, which is actually what the _**Should return a string representation of a number with `$` sign appended at the end**_ test is doing...

Is this meant to be that way?